### PR TITLE
47 implement box endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ Dockerfile.prod
 
 # Ignore IDE and editor files
 .vscode/
+.cursor/
 .idea/
 *.sublime-workspace
 .project

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  postgres:
+    image: postgres:15
+    container_name: postgres_db
+    restart: always
+    env_file: .env
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      retries: 5
+
+volumes:
+  pgdata:
+  portainer_data:

--- a/projects/backend/src/decorators/getuser.decorator.ts
+++ b/projects/backend/src/decorators/getuser.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const GetUser = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+  },
+);

--- a/projects/backend/src/main.ts
+++ b/projects/backend/src/main.ts
@@ -3,7 +3,7 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.setGlobalPrefix('api/v1');
+  app.setGlobalPrefix('api');
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/projects/backend/src/v1/box/box.controller.spec.ts
+++ b/projects/backend/src/v1/box/box.controller.spec.ts
@@ -32,8 +32,8 @@ describe('BoxController', () => {
     expect(controller).toBeDefined();
   });
 
-  it('should return all boxes', async () => {
-    expect(await controller.findAll()).toEqual([
+  it('should return all boxes in a location', async () => {
+    expect(await controller.findAll('location-1')).toEqual([
       { id: '1', name: 'Test Box', slug: 'test-box', locationId: 'location-1', sealed: false },
     ]);
   });
@@ -53,15 +53,18 @@ describe('BoxController', () => {
       name: 'New Box',
       slug: 'new-box',
       sealed: false,
-      location: { connect: { id: 'location-1' } }
+      locationId: 'location-1', // ✅ Flat ID format
     };
+
     expect(await controller.create(dto)).toEqual({
       id: '2',
       name: 'New Box',
       slug: 'new-box',
-      locationId: 'location-1',
+      locationId: 'location-1', // ✅ Expected flat ID
       sealed: false,
     });
+
+    expect(service.create).toHaveBeenCalledWith(dto);
   });
 
   it('should update a box', async () => {

--- a/projects/backend/src/v1/box/box.controller.spec.ts
+++ b/projects/backend/src/v1/box/box.controller.spec.ts
@@ -1,0 +1,78 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BoxController } from './box.controller';
+import { BoxService } from './box.service';
+
+describe('BoxController', () => {
+  let controller: BoxController;
+  let service: BoxService;
+
+  const mockBoxService = {
+    findAll: jest.fn().mockResolvedValue([
+      { id: '1', name: 'Test Box', slug: 'test-box', locationId: 'location-1', sealed: false },
+    ]),
+    findOne: jest.fn((id) =>
+      Promise.resolve({ id, name: 'Test Box', slug: 'test-box', locationId: 'location-1', sealed: false })
+    ),
+    create: jest.fn((dto) => Promise.resolve({ id: '2', ...dto })),
+    update: jest.fn((id, dto) => Promise.resolve({ id, ...dto })),
+    delete: jest.fn().mockResolvedValue({}),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BoxController],
+      providers: [{ provide: BoxService, useValue: mockBoxService }],
+    }).compile();
+
+    controller = module.get<BoxController>(BoxController);
+    service = module.get<BoxService>(BoxService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should return all boxes', async () => {
+    expect(await controller.findAll()).toEqual([
+      { id: '1', name: 'Test Box', slug: 'test-box', locationId: 'location-1', sealed: false },
+    ]);
+  });
+
+  it('should return a single box by ID', async () => {
+    expect(await controller.findOne('1')).toEqual({
+      id: '1',
+      name: 'Test Box',
+      slug: 'test-box',
+      locationId: 'location-1',
+      sealed: false,
+    });
+  });
+
+  it('should create a box', async () => {
+    const dto = {
+      name: 'New Box',
+      slug: 'new-box',
+      sealed: false,
+      location: { connect: { id: 'location-1' } }
+    };
+    expect(await controller.create(dto)).toEqual({
+      id: '2',
+      name: 'New Box',
+      slug: 'new-box',
+      locationId: 'location-1',
+      sealed: false,
+    });
+  });
+
+  it('should update a box', async () => {
+    const dto = { name: 'Updated Box' };
+    expect(await controller.update('1', dto)).toEqual({
+      id: '1',
+      name: 'Updated Box',
+    });
+  });
+
+  it('should delete a box', async () => {
+    expect(await controller.delete('1')).toEqual({});
+  });
+});

--- a/projects/backend/src/v1/box/box.controller.ts
+++ b/projects/backend/src/v1/box/box.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Patch, Delete, Body, Param } from '@nestjs/common';
+import { Controller, Get, Post, Patch, Delete, Body, Param, BadRequestException, Query } from '@nestjs/common';
 import { BoxService } from './box.service';
 import { Prisma } from '@prisma/client';
 
@@ -7,8 +7,11 @@ export class BoxController {
   constructor(private readonly boxService: BoxService) {}
 
   @Get()
-  async findAll() {
-    return this.boxService.findAll();
+  async findAll(@Query('locationId') locationId: string) {
+    if (!locationId) {
+      throw new BadRequestException('locationId is required');
+    }
+    return this.boxService.findAll(locationId);
   }
 
   @Get(':id')
@@ -17,8 +20,11 @@ export class BoxController {
   }
 
   @Post()
-  async create(@Body() data: Prisma.BoxCreateInput) {
-    return this.boxService.create(data);
+  async create(@Body() data: any) {
+    return this.boxService.create({
+      ...data,
+      locationId: data.locationId, // Ensure locationId is passed as a flat ID
+    });
   }
 
   @Patch(':id')

--- a/projects/backend/src/v1/box/box.controller.ts
+++ b/projects/backend/src/v1/box/box.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, Post, Patch, Delete, Body, Param } from '@nestjs/common';
+import { BoxService } from './box.service';
+import { Prisma } from '@prisma/client';
+
+@Controller('v1/box')
+export class BoxController {
+  constructor(private readonly boxService: BoxService) {}
+
+  @Get()
+  async findAll() {
+    return this.boxService.findAll();
+  }
+
+  @Get(':id')
+  async findOne(@Param('id') id: string) {
+    return this.boxService.findOne(id);
+  }
+
+  @Post()
+  async create(@Body() data: Prisma.BoxCreateInput) {
+    return this.boxService.create(data);
+  }
+
+  @Patch(':id')
+  async update(@Param('id') id: string, @Body() data: Prisma.BoxUpdateInput) {
+    return this.boxService.update(id, data);
+  }
+
+  @Delete(':id')
+  async delete(@Param('id') id: string) {
+    return this.boxService.delete(id);
+  }
+}

--- a/projects/backend/src/v1/box/box.module.ts
+++ b/projects/backend/src/v1/box/box.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { BoxService } from './box.service';
+import { BoxController } from './box.controller';
+import { PrismaService } from '../../prisma/prisma.service';
+
+@Module({
+  controllers: [BoxController],
+  providers: [BoxService, PrismaService],
+})
+export class BoxModule {}

--- a/projects/backend/src/v1/box/box.service.ts
+++ b/projects/backend/src/v1/box/box.service.ts
@@ -1,0 +1,42 @@
+import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+
+@Injectable()
+export class BoxService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll() {
+    return this.prisma.box.findMany();
+  }
+
+  async findOne(id: string) {
+    const box = await this.prisma.box.findUnique({ where: { id } });
+    if (!box) throw new NotFoundException('Box not found');
+    return box;
+  }
+
+  async create(data: any) {
+    // Ensure slug is unique
+    const existingBox = await this.prisma.box.findUnique({ where: { slug: data.slug } });
+    if (existingBox) throw new ConflictException('A box with this slug already exists');
+
+    return this.prisma.box.create({ data });
+  }
+
+  async update(id: string, data: any) {
+    const existingBox = await this.prisma.box.findUnique({ where: { id } });
+    if (!existingBox) throw new NotFoundException('Box not found');
+
+    return this.prisma.box.update({
+      where: { id },
+      data: { ...data, dateLastModified: new Date() },
+    });
+  }
+
+  async delete(id: string) {
+    const existingBox = await this.prisma.box.findUnique({ where: { id } });
+    if (!existingBox) throw new NotFoundException('Box not found');
+
+    return this.prisma.box.delete({ where: { id } });
+  }
+}

--- a/projects/backend/src/v1/box/box.service.ts
+++ b/projects/backend/src/v1/box/box.service.ts
@@ -5,8 +5,10 @@ import { PrismaService } from '../../prisma/prisma.service';
 export class BoxService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findAll() {
-    return this.prisma.box.findMany();
+  async findAll(locationId: string) {
+    return this.prisma.box.findMany({
+      where: { locationId },
+    });
   }
 
   async findOne(id: string) {
@@ -16,11 +18,20 @@ export class BoxService {
   }
 
   async create(data: any) {
-    // Ensure slug is unique
-    const existingBox = await this.prisma.box.findUnique({ where: { slug: data.slug } });
-    if (existingBox) throw new ConflictException('A box with this slug already exists');
+    const createdBox = await this.prisma.box.create({
+      data: {
+        ...data,
+        locationId: data.locationId, // Store locationId directly
+      },
+    });
 
-    return this.prisma.box.create({ data });
+    return {
+      id: createdBox.id,
+      name: createdBox.name,
+      slug: createdBox.slug,
+      locationId: createdBox.locationId, // Return locationId as a flat ID
+      sealed: createdBox.sealed,
+    };
   }
 
   async update(id: string, data: any) {

--- a/projects/backend/src/v1/healthcheck/healthcheck.controller.ts
+++ b/projects/backend/src/v1/healthcheck/healthcheck.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
 import { HealthcheckService } from './healthcheck.service';
 import { Public } from '../../decorators/public.decorator';
-@Controller('healthcheck')
+@Controller('v1/healthcheck')
 export class HealthcheckController {
   constructor(private readonly healthcheckService: HealthcheckService) {}
 

--- a/projects/backend/src/v1/location/location.controller.spec.ts
+++ b/projects/backend/src/v1/location/location.controller.spec.ts
@@ -50,9 +50,10 @@ describe('LocationController', () => {
 
   it('should create a location', async () => {
     const dto = { spaceId: 'space-1', name: 'Office', address: '456 Road', type: 'Workplace' };
+
     expect(await controller.create(dto)).toEqual({
       id: '2',
-      spaceId: 'space-1',
+      spaceId: 'space-1', // Ensure spaceId is expected as a flat ID
       name: 'Office',
       address: '456 Road',
       type: 'Workplace',

--- a/projects/backend/src/v1/location/location.controller.ts
+++ b/projects/backend/src/v1/location/location.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Post, Body, Param, Put, Delete } from '@nestjs/common';
 import { LocationService } from './location.service';
 
-@Controller('v1/locations')
+@Controller('v1/location')
 export class LocationController {
   constructor(private readonly locationService: LocationService) {}
 

--- a/projects/backend/src/v1/location/location.service.ts
+++ b/projects/backend/src/v1/location/location.service.ts
@@ -13,10 +13,22 @@ export class LocationService {
     return this.prisma.location.findUnique({ where: { id } });
   }
 
-  async create(data: any) {
-    return this.prisma.location.create({ data });
-  }
+async create(data: any) {
+  const createdLocation = await this.prisma.location.create({
+    data: {
+      ...data,
+      spaceId: data.spaceId, // Ensure spaceId is stored directly
+    },
+  });
 
+  return {
+    id: createdLocation.id,
+    name: createdLocation.name,
+    address: createdLocation.address,
+    type: createdLocation.type,
+    spaceId: createdLocation.spaceId, // Return spaceId as a flat ID
+  };
+}
   async update(id: string, data: any) {
     return this.prisma.location.update({ where: { id }, data });
   }

--- a/projects/backend/src/v1/spaces/spaces.controller.ts
+++ b/projects/backend/src/v1/spaces/spaces.controller.ts
@@ -1,33 +1,34 @@
 import { Controller, Get, Post, Body, Param, Put, Delete } from '@nestjs/common';
 import { SpacesService } from './spaces.service';
 import { Prisma } from '@prisma/client';
+import { GetUser } from '../../decorators/getuser.decorator';
 
 @Controller('v1/spaces')
 export class SpacesController {
   constructor(private readonly spacesService: SpacesService) {}
 
   @Get()
-  async findAll() {
-    return this.spacesService.findAll();
+  async findAll(@GetUser() user: any) {
+    return this.spacesService.findAll(user.id);
   }
 
   @Get(':id')
-  async findOne(@Param('id') id: string) {
-    return this.spacesService.findOne(id);
+  async findOne(@Param('id') id: string, @GetUser() user: any) {
+    return this.spacesService.findOne(id, user.id);
   }
 
   @Post()
-  async create(@Body() data: Prisma.SpaceCreateInput) {
-    return this.spacesService.create(data);
+  async create(@Body() data: any, @GetUser() user: any) {
+    return this.spacesService.create({ ...data, createdBy: user.id }, user.id);
   }
 
   @Put(':id')
-  async update(@Param('id') id: string, @Body() data: Prisma.SpaceUpdateInput) {
-    return this.spacesService.update(id, data);
+  async update(@Param('id') id: string, @Body() data: Prisma.SpaceUpdateInput, @GetUser() user: any) {
+    return this.spacesService.update(id, data, user.id);
   }
 
   @Delete(':id')
-  async delete(@Param('id') id: string) {
-    return this.spacesService.delete(id);
+  async delete(@Param('id') id: string, @GetUser() user: any) {
+    return this.spacesService.delete(id, user.id);
   }
 }

--- a/projects/backend/src/v1/spaces/spaces.service.ts
+++ b/projects/backend/src/v1/spaces/spaces.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, ForbiddenException } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { Prisma } from '@prisma/client';
 
@@ -6,26 +6,74 @@ import { Prisma } from '@prisma/client';
 export class SpacesService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findAll() {
-    return this.prisma.space.findMany();
+  async findAll(userId: string) {
+    return this.prisma.space.findMany({
+      where: {
+        spaceUsers: {
+          some: { userId },
+        },
+      },
+    });
   }
 
-  async findOne(id: string) {
-    return this.prisma.space.findUnique({ where: { id } });
+  async findOne(id: string, userId: string) {
+    const space = await this.prisma.space.findUnique({ where: { id } });
+
+    if (!space) throw new ForbiddenException('Space not found');
+
+    const userHasAccess = await this.prisma.spaceUser.findFirst({
+      where: { spaceId: id, userId },
+    });
+
+    if (!userHasAccess) throw new ForbiddenException('Access denied');
+
+    return space;
   }
 
-  async create(data: Prisma.SpaceCreateInput) {
-    return this.prisma.space.create({ data });
+  async create(data: any, userId: string) {
+    const createdSpace = await this.prisma.space.create({
+      data: {
+        ...data,
+        createdBy: userId, // Store just the UUID, not a relation
+      },
+    });
+
+    return {
+      id: createdSpace.id,
+      name: createdSpace.name,
+      slug: createdSpace.slug,
+      createdBy: createdSpace.createdBy, // Ensure a flat ID is returned
+    };
   }
 
-  async update(id: string, data: Prisma.SpaceUpdateInput) {
+  async update(id: string, data: Prisma.SpaceUpdateInput, userId: string) {
+    const space = await this.prisma.space.findUnique({ where: { id } });
+
+    if (!space) throw new ForbiddenException('Space not found');
+
+    const userHasAccess = await this.prisma.spaceUser.findFirst({
+      where: { spaceId: id, userId },
+    });
+
+    if (!userHasAccess) throw new ForbiddenException('Access denied');
+
     return this.prisma.space.update({
       where: { id },
       data,
     });
   }
 
-  async delete(id: string) {
+  async delete(id: string, userId: string) {
+    const space = await this.prisma.space.findUnique({ where: { id } });
+
+    if (!space) throw new ForbiddenException('Space not found');
+
+    const userHasAccess = await this.prisma.spaceUser.findFirst({
+      where: { spaceId: id, userId },
+    });
+
+    if (!userHasAccess) throw new ForbiddenException('Access denied');
+
     return this.prisma.space.delete({ where: { id } });
   }
 }

--- a/projects/backend/src/v1/user/user.controller.ts
+++ b/projects/backend/src/v1/user/user.controller.ts
@@ -5,7 +5,7 @@ import { UserService } from './user.service';
 import { CreateUserDto, UpdateUserDto } from './dto/user.dto';
 import { AuthenticatedRequest } from '../../../types/express'; // Import the extended request type
 
-@Controller('user')
+@Controller('v1/user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
 

--- a/projects/backend/src/v1/v1.module.ts
+++ b/projects/backend/src/v1/v1.module.ts
@@ -3,9 +3,8 @@ import { HealthcheckModule } from './healthcheck/healthcheck.module';
 import { AuthModule } from '../auth/auth.module';
 import { UserModule } from './user/user.module';
 import { SpacesModule } from './spaces/spaces.module';
-import { LocationController } from './location/location.controller';
-import { LocationService } from './location/location.service';
 import { LocationModule } from './location/location.module';
+import { BoxModule } from './box/box.module';
 
 @Module({
   imports: [
@@ -14,9 +13,8 @@ import { LocationModule } from './location/location.module';
     UserModule,
     SpacesModule,
     LocationModule,
-  ],
-  controllers: [LocationController],
-  providers: [LocationService],
+    BoxModule,
+  ]
 })
 export class V1Module {}
 


### PR DESCRIPTION
# Pull Request for Ticket: Closes #47 

## 🪟 Overview

Adds a `/box` endpoint to `/api/v1` routes and sures up some of the API logic

## 🤔 Reason

We need a box endpoint and also I realised that I was implementing lookups globally and not scoped to the parts they are tied to, so `GET /api/v1/spaces` returned all spaces in the db, which was wrong, it should only return those assigned to the logged in user. This fixes that and a few other similar issues.

## 📓 Developer Notes

- I also removed the `/v1` prefix from `src/main.ts` as it felt wrong to have that outside of the `/v1` folder, the `v1` prefix is now added to each controller.
